### PR TITLE
Fix broken call in ObsBandpass

### DIFF
--- a/pysynphot/spectrum.py
+++ b/pysynphot/spectrum.py
@@ -2467,7 +2467,7 @@ class SpectralElement(Integrator):
 
         """
         # See https://aeon.stsci.edu/ssb/trac/astrolib/ticket/169
-        return self.__call__(self._wavetable)
+        return self.__call__(self.GetWaveSet())
 
     throughput = property(GetThroughput, doc='Throughput property.')
 


### PR DESCRIPTION
Another attempt to address #8. Fixes bug introduced by #10 after looking at regression test results (`ObsBandpass` has no `_wavetable` attribute).