### PR TITLE
Redshift wavelength calculation now done in double precision

### DIFF
--- a/pysynphot/spectrum.py
+++ b/pysynphot/spectrum.py
@@ -675,7 +675,7 @@ class SourceSpectrum(Integrator):
         fluxunits = self.fluxunits
         self.convert('angstrom')
         self.convert('photlam')
-        newwave = self.wave*(1.0+z)
+        newwave = self.wave.astype(N.float64) * (1.0 + z)
         copy = ArraySourceSpectrum(wave=newwave,
                                    flux=self.flux,
                                    waveunits=self.waveunits,


### PR DESCRIPTION
Redshift wavelength calculation now done in double precision. Otherwise, some wavelengths are merged unnecessarily, resulting in loss in sampling. Example:

```python
>>> import pysynphot as S
>>> from pysynphot.spparser import parse_spec
>>> obsmode = 'wfc3,uvis1,f555w'
>>> spectrum = ('rn(z(spec($PYSYN_CDBS/calspec/bd_28d4211_stis_001.fits),'
...             '0.1),band(johnson,b),28.0,vegamag)')
>>> sp = parse_spec(spectrum)
>>> bp = S.ObsBandpass(obsmode)
>>> obs = S.Observation(sp, bp)
>>> obs_ref.wave[11044:11049]  # AFTER this fix
array([ 8721.        ,  8722.        ,  8722.39453125,  8722.39467773,
        8723.        ])
```

Without this fix, `8722.39453125,  8722.39467773` are merged as `8722.39453125` under single-precision calculations.