### PR TITLE
Raise exception when catalog gap detected

### DIFF
--- a/pysynphot/catalog.py
+++ b/pysynphot/catalog.py
@@ -204,6 +204,11 @@ class Icat(spectrum.TabularSourceSpectrum):
                                                   os.path.join(basename,filename))
         sp = spectrum.TabularSourceSpectrum(filename, fluxname=column)
 
+        totflux = sp.integrate()
+        if not N.isfinite(totflux) or totflux <= 0:
+            raise exceptions.ParameterOutOfBounds(
+                "Parameter '{0}' has no valid data.".format(parlist))
+
         result = []
         for member in parlist:
             result.append(member)

--- a/pysynphot/test/test_catalog.py
+++ b/pysynphot/test/test_catalog.py
@@ -66,13 +66,13 @@ class ICatK93Test(object):
 
 @use_cdbs
 @pytest.mark.parametrize(
-  ('teff', 'z', 'logg'),
-  [(6440, 0, 10),
-   (6440, 0, -1),
-   (1.e6, 0, 4.3),
-   (100, 0, 4.3),
-   (6440, 2, 4.3),
-   (6440, -6, 4.3)])
+    ('teff', 'z', 'logg'),
+    [(6440, 0, 10),
+     (6440, 0, -1),
+     (1.e6, 0, 4.3),
+     (100, 0, 4.3),
+     (6440, 2, 4.3),
+     (6440, -6, 4.3)])
 def test_Icat_exceptions(teff, z, logg):
     """
     Tests for changes related to Trac ticket #211.
@@ -80,6 +80,18 @@ def test_Icat_exceptions(teff, z, logg):
     """
     with pytest.raises(ParameterOutOfBounds):
         Icat('k93models', teff, z, logg)
+
+
+@use_cdbs
+def test_phoenix_gap():
+    """
+    https://github.com/spacetelescope/pysynphot/issues/68
+    """
+    Icat('phoenix', 2700, -1, 5.1)  # OK
+    with pytest.raises(ParameterOutOfBounds):
+        Icat('phoenix', 2700, -0.5, 5.1)
+    with pytest.raises(ParameterOutOfBounds):
+        Icat('phoenix', 2700, -0.501, 5.1)
 
 
 @use_cdbs


### PR DESCRIPTION
Fix #68 . Same solution as spacetelescope/stsynphot_refactor#48.  Do not merge this until that one is approved and merged.

~~@mgennaro , do you want to take this for a spin and see if this is the fix you were looking for?~~

**To test this in your conda environment**

If you have previously cloned my fork, you can skip this
```
git clone https://github.com/pllim/pysynphot.git
```

Then
```
git checkout stop-gap
python setup.py install
```