### PR TITLE
Consolidate relic initialization

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,18 +8,21 @@ from setuptools import setup, Extension
 from subprocess import check_call, CalledProcessError
 
 
-try:
-    if pkgutil.find_loader('relic'):
-        pass
-    elif os.path.exists('relic') and not os.listdir('relic'):
-        check_call(['git', 'submodule', 'update', '--init', '--recursive'])
-    elif not os.path.exists('relic'):
-        check_call(['git', 'clone', 'https://github.com/jhunkeler/relic.git'])
+if not pkgutil.find_loader('relic'):
+    relic_local = os.path.exists('relic')
+    relic_submodule = (relic_local and
+                       os.path.exists('.gitmodules') and
+                       not os.listdir('relic'))
+    try:
+        if relic_submodule:
+            check_call(['git', 'submodule', 'update', '--init', '--recursive'])
+        elif not relic_local:
+            check_call(['git', 'clone', 'https://github.com/jhunkeler/relic.git'])
 
-    sys.path.insert(1, 'relic')
-except CalledProcessError as e:
-    print(e)
-    exit(1)
+        sys.path.insert(1, 'relic')
+    except CalledProcessError as e:
+        print(e)
+        exit(1)
 
 import relic.release  # noqa
 

--- a/setup.py
+++ b/setup.py
@@ -1,11 +1,26 @@
 #!/usr/bin/env python
+import os
+import pkgutil
 import sys
 from glob import glob
 from numpy import get_include as np_include
 from setuptools import setup, Extension
+from subprocess import check_call, CalledProcessError
 
-# Use submodule
-sys.path.insert(1, 'relic')
+
+try:
+    if pkgutil.find_loader('relic'):
+        pass
+    elif os.path.exists('relic') and not os.listdir('relic'):
+        check_call(['git', 'submodule', 'update', '--init', '--recursive'])
+    elif not os.path.exists('relic'):
+        check_call(['git', 'clone', 'https://github.com/jhunkeler/relic.git'])
+
+    sys.path.insert(1, 'relic')
+except CalledProcessError as e:
+    print(e)
+    exit(1)
+
 import relic.release  # noqa
 
 version = relic.release.get_info()


### PR DESCRIPTION
1. Use `pkgutil` to determine if `relic` has been installed (i.e. `pip`). If so, fall through to `import relic.release`.
2. Check whether `relic` exists and is an empty directory (90% chance it's a submodule). If so, initialize the `relic` submodule.
3. Check whether `relic` does not exist. If not, clone `relic`
4. If either the submodule initialization or clone operation succeed, insert the local `relic` directory into `sys.path`

In all cases `import relic.release` occurs only once.