### PR TITLE
Jahia link update

### DIFF
--- a/doc/source/appendixa.rst
+++ b/doc/source/appendixa.rst
@@ -181,7 +181,7 @@ Phoenix Models
 The ``$PYSYN_CDBS/grid/phoenix`` directory contains models provided by
 `F. Allard et al. <http://perso.ens-lyon.fr/france.allard/>`_
 and can be found in the
-`Star, Brown Dwarf, and Planet Simulator <http://phoenix.ens-lyon.fr/simulator/index.faces>`_. They use static, spherical symmetric, 1D simulations to completely
+`Star, Brown Dwarf, and Planet Simulator <https://phoenix.ens-lyon.fr/simulator/index.faces>`_. They use static, spherical symmetric, 1D simulations to completely
 describe the atmospheric emission spectrum. The models account for the
 formation of molecular bands, such as those of water vapor, methane, or
 titanium dioxide, solving for the transfer equation over more than 20,000

--- a/doc/source/appendixa.rst
+++ b/doc/source/appendixa.rst
@@ -190,7 +190,7 @@ resolution. The line selection is repeated at each iteration of the model
 until it has converged and the thermal structure obtained. The models here
 are calculated with a cloud model, valid across the entire parameter range.
 See
-`Phoenix models README file <http://www.stsci.edu/hst/observatory/crds/SIfileInfo/pysynphottables/index_phoenix_models_html>`_
+`Phoenix models README file <http://www.stsci.edu/hst/instrumentation/reference-data-for-calibration-and-tools/astronomical-catalogs/phoenix-models-available-in-pysynphot>`_
 for more details.
 The atlas data files are organized in a similar naming convention as
 :ref:`pysynphot-appendixa-kurucz1993`, and are easily accessible using

--- a/doc/source/appendixa.rst
+++ b/doc/source/appendixa.rst
@@ -10,7 +10,7 @@ with **pysynphot**. They are as tabulated below.
 
 Current descriptions and access to all available
 calibration spectra and astronomical catalogs be found at the
-`CRDS website <http://www.stsci.edu/hst/observatory/crds/astronomical_catalogs.html>`_,
+`CRDS website <http://www.stsci.edu/hst/instrumentation/reference-data-for-calibration-and-tools/astronomical-catalogs.html>`_,
 which supersedes this documentation in case of conflicting information.
 The data files are available at STScI on all science computing clusters in the
 ``$PYSYN_CDBS`` directory. Off-site users can obtain these data via
@@ -71,7 +71,7 @@ in CRDS are from "the Grids of ATLAS9-ODFNEW Models and Fluxes" from
 `Dr. F. Castelli's webpage <http://wwwuser.oats.inaf.it/castelli/grids.html>`_
 (created on January 2007) and also available from
 `Dr. R. Kurucz's webpage <http://kurucz.harvard.edu>`_. See
-`Castelli-Kurucz 2004 atlas README file <http://www.stsci.edu/hst/observatory/crds/castelli_kurucz_atlas.html>`_
+`Castelli-Kurucz 2004 atlas README file <http://www.stsci.edu/hst/instrumentation/reference-data-for-calibration-and-tools/astronomical-catalogs/castelli-and-kurucz-atlas.html>`_
 for more details.
 The atlas data files are organized in a similar naming convention as
 :ref:`pysynphot-appendixa-kurucz1993`, and are easily accessible using
@@ -259,7 +259,7 @@ limit of the instrument. As a result, **pysynphot** may underestimate the total
 counts. Users should check that the wavelength range of the spectrum they are
 using is compatible with the wavelength range of the calculation they require.
 
-See `CALSPEC Calibration Database <http://www.stsci.edu/hst/observatory/crds/calspec.html>`_
+See `CALSPEC Calibration Database <http://www.stsci.edu/hst/instrumentation/reference-data-for-calibration-and-tools/astronomical-catalogs/calspec.html>`_
 for available spectra and their descriptions.
 
 
@@ -275,7 +275,7 @@ stellar spectra, encompassing all normal spectral types and luminosity
 classes at solar abundance, and metal-weak and metal-rich F-K dwarf
 and G-K giant components. Each spectrum in the library is a combination of
 several sources overlapping in wavelength coverage. See
-`Pickles library README file <http://www.stsci.edu/hst/observatory/crds/pickles_atlas.html>`_
+`Pickles library README file <http://www.stsci.edu/hst/instrumentation/reference-data-for-calibration-and-tools/astronomical-catalogs/pickles-atlas.html>`_
 for more details.
 
 The library data were obtained from
@@ -319,7 +319,7 @@ atmospheres. It consists of 1434 files, each of which represents a metal-line
 blanketed flux spectrum for a theoretical stellar model atmosphere.
 Data files are named "bk_mnnnn.fits", where ``m`` is the block code and
 ``nnnn`` the sequence number. See
-`Buser-Kurucz atlas README file <http://www.stsci.edu/hst/observatory/crds/bkmodels.html>`_
+`Buser-Kurucz atlas README file <http://www.stsci.edu/hst/instrumentation/reference-data-for-calibration-and-tools/astronomical-catalogs/buser-kurucz-atlas.html>`_
 for more details, in including the mapping of filenames to their respective
 parameter specifications.
 
@@ -341,7 +341,7 @@ The ``$PYSYN_CDBS/grid/bz77`` directory contains 77 stellar spectra that are
 frequently used in the synthesis of galaxy spectra. They were provided by
 Gustavo Bruzual. Each spectrum is stored in a table named "bz_nn.fits",
 where ``nn`` runs from 1 to 77. See
-`Bruzual atlas README file <http://www.stsci.edu/hst/observatory/crds/bz77.html>`_
+`Bruzual atlas README file <http://www.stsci.edu/hst/instrumentation/reference-data-for-calibration-and-tools/astronomical-catalogs/bruzual-atlas.html>`_
 for a mapping of filenames to their respective spectral types.
 
 The example below loads a source spectrum of spectral type G5V from the atlas:
@@ -363,7 +363,7 @@ classes from the observations of
 The spectra cover the wavelength range 3130 to 10800 Angstroms.
 Each spectrum is stored in a table named "gs_nnn.fits",
 where ``nnn`` runs from 1 to 175. See
-`Gunn-Stryker atlas README file <http://www.stsci.edu/hst/observatory/crds/gs.html>`_
+`Gunn-Stryker atlas README file <http://www.stsci.edu/hst/instrumentation/reference-data-for-calibration-and-tools/astronomical-catalogs/gunn-stryker-atlas-list.html>`_
 for a mapping of filenames to their respective spectral types.
 
 The example below loads a source spectrum of spectral type G5V from the atlas:
@@ -386,7 +386,7 @@ sources. The IR and the optical data are tied together by the :math:`V – K`
 colors.
 Each spectrum is stored in a table named "bpgs_nnn.fits",
 where ``nnn`` runs from 1 to 175. See
-`Bruzual-Persson-Gunn-Stryker atlas README file <http://www.stsci.edu/hst/observatory/crds/bpgs.html>`_
+`Bruzual-Persson-Gunn-Stryker atlas README file <http://www.stsci.edu/hst/instrumentation/reference-data-for-calibration-and-tools/astronomical-catalogs/bruzual-persson-gunn-stryker-atlas-list.html>`_
 for a mapping of filenames to their respective spectral types.
 
 Note that the spectral data for all of the stars in this atlas have been
@@ -418,7 +418,7 @@ They cover the wavelength range 3510 to 7427 Angstroms at a resolution of
 approximately 4.5 Angstroms.
 Each spectrum is stored in a table named "jc_nnn.fits",
 where ``nnn`` runs from 1 to 161. See
-`Jacoby-Hunter-Christian atlas README file <http://www.stsci.edu/hst/observatory/crds/JHC.html>`_
+`Jacoby-Hunter-Christian atlas README file <http://www.stsci.edu/hst/instrumentation/reference-data-for-calibration-and-tools/astronomical-catalogs/jacoby-hunter-christian-atlas.html>`_
 for a mapping of filenames to their respective spectral types.
 
 The example below loads a source spectrum of spectral type G0V from the atlas:
@@ -443,7 +443,7 @@ Each spectrum has 1187 wavelength points covering the 0.01 to 100 microns range.
 The flux unit is solar luminosity per Angstrom.
 The nebular contribution to the SED (i.e., emission lines and nebular continuum)
 is not included in the spectra. See
-`Bruzual-Charlot atlas README file <http://www.stsci.edu/hst/observatory/crds/cdbs_bc95.html>`_
+`Bruzual-Charlot atlas README file <http://www.stsci.edu/hst/instrumentation/reference-data-for-calibration-and-tools/astronomical-catalogs/the-bruzual-charlot-atlas.html>`_
 for available spectra and their descriptions.
 
 The example below loads a galaxy spectrum with Salpeter IMF containing mass
@@ -466,7 +466,7 @@ types (:ref:`Kinney et al. 1996 <synphot-ref-kinney1996>`) and starburst
 galaxies (:ref:`Calzetti et al. 1994 <synphot-ref-calzetti1994>`).
 The flux of the spectral templates has been normalized to a visual magnitude
 of 12.5 ``stmag``. See
-`Kinney-Calzetti atlas README file <http://www.stsci.edu/hst/observatory/crds/cdbs_kc96.html>`_
+`Kinney-Calzetti atlas README file <http://www.stsci.edu/hst/instrumentation/reference-data-for-calibration-and-tools/astronomical-catalogs/the-kinney-calzetti-spetral-atlas.html>`_
 for more details.
 
 The example below loads a galaxy spectrum from the elliptical template:
@@ -488,7 +488,7 @@ J. R. Walsh, private communication).
 The flux of the LINER and Seyfert 2 templates is normalized to a Johnson *V*
 magnitude of 12.5 ``stmag``, while the Seyfert 1 and QSO templates are
 normalized to a Johnson *B* magnitude of 12.5 ``stmag``. See
-`AGN atlas README file <http://www.stsci.edu/hst/observatory/crds/cdbs_agn.html>`_
+`AGN atlas README file <http://www.stsci.edu/hst/instrumentation/reference-data-for-calibration-and-tools/astronomical-catalogs/the-agn-atlas.html>`_
 for more details.
 
 The example below loads a Seyfert 2 spectrum:
@@ -506,7 +506,7 @@ Galactic Atlas
 The ``$PYSYN_CDBS/grid/galactic`` directory contains the model spectra of
 Orion nebula and NGC 7009 planetary nebula (J. R. Walsh, private communication).
 See
-`Galactic atlas README file <http://www.stsci.edu/hst/observatory/crds/cdbs_galactic.html>`_
+`Galactic atlas README file <http://www.stsci.edu/hst/instrumentation/reference-data-for-calibration-and-tools/astronomical-catalogs/the-galactic-emission-line-object-atlas.html>`_
 for more details.
 
 The example below loads the spectrum for Orion nebula:
@@ -522,8 +522,8 @@ Other Non-Stellar Objects
 =========================
 
 The ``$PYSYN_CDBS/etc/source`` directory contains spectra for
-`various non-stellar objects used in ETC <http://etc.stsci.edu/etcstatic/users_guide/1_ref_2_spectral_distribution.html#non-stellar-spectra>`_. See `Non-stellar objects README file <http://www.stsci.edu/hst/observatory/crds/non-stellar.html>`_
-for more details.
+`various non-stellar objects used in ETC <http://etc.stsci.edu/etcstatic/users_guide/1_ref_2_spectral_distribution.html#non-stellar-spectra>`_.
+See `Non-stellar spectra <http://www.stsci.edu/hst/instrumentation/reference-data-for-calibration-and-tools/astronomical-catalogs/non-stellar-spectra.html>`_ for more details.
 
 The example below loads a spectrum for Gliese 229B brown dwarf:
 

--- a/doc/source/appendixb.rst
+++ b/doc/source/appendixb.rst
@@ -1211,7 +1211,7 @@ The filter curves are shown in the
 
 The throughput data give the system photon response to point sources of the
 2.5-m SDSS survey telescope, including extinction through an airmass of 1.3 at
-`Apache Point Observatory <http://www.apo.nmsu.edu/>`_ (to which all SDSS
+`Apache Point Observatory <https://www.apo.nmsu.edu/>`_ (to which all SDSS
 photometry is referenced).
 Originally, the *ugriz* system was intended to be identical to the
 :math:`u^{\prime} g^{\prime} r^{\prime} i^{\prime} z^{\prime}`
@@ -1221,7 +1221,7 @@ and defined by the standard star system in
 of processing the SDSS data, an unpleasant discovery was made that
 the filters in the 2.5-m telescope have significantly different
 effective wavelengths from the filters in the
-`USNO <http://www.usno.navy.mil/USNO/>`_ telescope, which was used to observe
+`USNO <https://www.usno.navy.mil/USNO/>`_ telescope, which was used to observe
 the :math:`u^{\prime} g^{\prime} r^{\prime} i^{\prime} z^{\prime}`
 standards; The difference originates from the USNO filters being exposed to
 ambient air, while the survey-telescope filters live in the vacuum of the

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -10,8 +10,8 @@ Introduction
 Astrolib PySynphot (hereafter referred to only as **pysynphot**) is an
 object-oriented replacement for STSDAS SYNPHOT synthetic photometry package in
 IRAF. It is distributed as part of
-`AstroConda <http://astroconda.readthedocs.io/en/latest/>`_ (preferred)
-and also as `standalone <https://pypi.python.org/pypi/pysynphot/>`_.
+`AstroConda <https://astroconda.readthedocs.io/en/latest/>`_ (preferred)
+and also as `standalone <https://pypi.org/project/pysynphot/>`_.
 Although this package was developed for HST, it can be utilized with other
 observatories.
 
@@ -62,9 +62,9 @@ To install the PyPI release::
 
 If missing, the following dependencies must also be installed:
 
-* `astropy <https://pypi.python.org/pypi/astropy>`_ 1.1 or greater
-* `numpy <https://pypi.python.org/pypi/numpy>`_ 1.9 or greater
-* `matplotlib <http://matplotlib.org/>`_ (optional)
+* `astropy https://pypi.org/project/astropy/>`_ 1.1 or greater
+* `numpy <https://pypi.org/project/numpy/>`_ 1.9 or greater
+* `matplotlib <https://matplotlib.org/>`_ (optional)
 
 Data files for **pysynphot** are distributed separately by
 `Calibration Reference Data System <http://www.stsci.edu/hst/instrumentation/reference-data-for-calibration-and-tools/synphot-throughput-tables.html>`_.
@@ -164,7 +164,7 @@ packages are already imported:
 >>> import pysynphot as S
 
 For plotting, make sure you have the optional
-`matplotlib <http://matplotlib.org/>`_ package and turn on its interactive mode:
+`matplotlib <https://matplotlib.org/>`_ package and turn on its interactive mode:
 
 >>> import matplotlib.pyplot as plt
 >>> plt.ion()
@@ -231,7 +231,7 @@ References
 
 .. _synphot-ref-demarchi2004:
 
-* `De Marchi, G. et al. 2004, ISR ACS 2004-08: Detector Quantum Efficiency and Photometric Zero Points of the ACS (Baltimore, MD: STScI) <http://www.stsci.edu/hst/instrumentation/acs/documentation/instrument-science-reports-isrs/_documents/isr0408.pdf>`_
+* `De Marchi, G. et al. 2004, ISR ACS 2004-08: Detector Quantum Efficiency and Photometric Zero Points of the ACS (Baltimore, MD: STScI) <http://www.stsci.edu/files/live/sites/www/files/home/hst/instrumentation/acs/documentation/instrument-science-reports-isrs/_documents/isr0408.pdf>`_
 
 .. _synphot-ref-diaz2012:
 
@@ -313,7 +313,7 @@ References
 
 * Maiz Apellaniz, J. 2006, AJ, 131, 1184
 
-* `matplotlib Tutorial <http://matplotlib.org/users/pyplot_tutorial.html>`_
+* `matplotlib Tutorial <https://matplotlib.org/users/pyplot_tutorial.html>`_
 
 .. _synphot-ref-morrissey2007:
 

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -295,7 +295,7 @@ References
 
 .. _synphot-ref-laidler2008:
 
-* `Laidler, V., et al. 2008, Synphot Data User's Guide, Version 1.2 (Baltimore, MD: STScI) <http://www.stsci.edu/hst/HST_overview/documents/synphot/hst_synphotTOC.html>`_
+* `Laidler, V., et al. 2008, Synphot Data User's Guide, Version 1.2 (Baltimore, MD: STScI) <http://www.stsci.edu/files/live/sites/www/files/home/hst/documentation/_documents/hst_synphot.pdf>`_
 
 .. _synphot-ref-landolt1983:
 

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -44,7 +44,7 @@ Alternately, bibcode is available from
 `Astrophysics Source Code Library <http://ascl.net/1303.023>`_.
 
 If you have questions or concerns regarding the software, please contact
-STScI Help Desk via ``help[at]stsci.edu``.
+STScI Help Desk via `hsthelp.stsci.edu <https://hsthelp.stsci.edu>`_.
 
 
 .. _pysynphot-installation-setup:
@@ -67,7 +67,7 @@ If missing, the following dependencies must also be installed:
 * `matplotlib <http://matplotlib.org/>`_ (optional)
 
 Data files for **pysynphot** are distributed separately by
-`Calibration Reference Data System <http://www.stsci.edu/hst/observatory/crds/throughput.html>`_.
+`Calibration Reference Data System <http://www.stsci.edu/hst/instrumentation/reference-data-for-calibration-and-tools/synphot-throughput-tables.html>`_.
 They are expected to follow a certain directory structure under the root
 directory, identified by the ``PYSYN_CDBS`` environment variable that *must* be
 set prior to using this package. In the example below, the root directory is
@@ -231,7 +231,7 @@ References
 
 .. _synphot-ref-demarchi2004:
 
-* `De Marchi, G. et al. 2004, ISR ACS 2004-08: Detector Quantum Efficiency and Photometric Zero Points of the ACS (Baltimore, MD: STScI) <http://www.stsci.edu/hst/acs/documents/isrs/isr0408.pdf>`_
+* `De Marchi, G. et al. 2004, ISR ACS 2004-08: Detector Quantum Efficiency and Photometric Zero Points of the ACS (Baltimore, MD: STScI) <http://www.stsci.edu/hst/instrumentation/acs/documentation/instrument-science-reports-isrs/_documents/isr0408.pdf>`_
 
 .. _synphot-ref-diaz2012:
 
@@ -335,9 +335,9 @@ References
 
 * Prevot, M. L., Lequeux, J., Prevot, L., Maurice, E., & Rocca-Volmerange, B. 1984, A&A, 132, 389
 
-* `pysynphot Code Repository <https://aeon.stsci.edu/ssb/trac/astrolib/browser/trunk/pysynphot>`_
+* `pysynphot Code Repository <https://github.com/spacetelescope/pysynphot/>`_
 
-* `pysynphot Open Issues <https://aeon.stsci.edu/ssb/trac/astrolib/query?status=assigned&status=new&status=reopened&component=pysynphot&col=id&col=summary&col=owner&col=type&col=status&col=priority&col=milestone&order=priority>`_
+* `pysynphot Open Issues <https://github.com/spacetelescope/pysynphot/issues>`_
 
 .. _synphot-ref-rybicki1979:
 

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -235,7 +235,7 @@ References
 
 .. _synphot-ref-diaz2012:
 
-* `Diaz, R.I. 2012, ISR CDBS 2012-01: pysynphot/Synphot Throughput Files: Mapping to instrument components for ACS, COS, and WFC3 (Baltimore, MD: STScI) <http://www.stsci.edu/hst/observatory/crds/documents/TIR-CDBS-2012-01.pdf>`_
+* `Diaz, R.I. 2012, ISR CDBS 2012-01: pysynphot/Synphot Throughput Files: Mapping to instrument components for ACS, COS, and WFC3 (Baltimore, MD: STScI) <http://www.stsci.edu/files/live/sites/www/files/home/hst/instrumentation/reference-data-for-calibration-and-tools/documentation/_documents/TIR-CDBS-2012-01.pdf>`_
 
 .. _synphot-ref-francis1991:
 

--- a/doc/source/observation.rst
+++ b/doc/source/observation.rst
@@ -82,7 +82,7 @@ observation. Therefore, it is ideally suited for predicting exposure times
 
 #. The input parameters were originally structured to mimic what is contained
    in the exposure logsheets found in HST observing proposals in
-   `Astronomer's Proposal Tool (APT) <http://www.stsci.edu/hst/proposing/apt>`_.
+   `Astronomer's Proposal Tool (APT) <http://www.stsci.edu/scientific-community/software/astronomers-proposal-tool-apt.html>`_.
 #. For the spectroscopic instruments, it will automatically search for and
    use a :ref:`wavelength table <pysynphot-wavelength-table>` that is
    appropriate for the selected instrumental dispersion mode.

--- a/doc/source/tutorials.rst
+++ b/doc/source/tutorials.rst
@@ -497,8 +497,8 @@ Tutorial 9: Bandpass ``stmag`` Zeropoint
 HST bandpasses store their :ref:`pysynphot-formula-uresp` values under the
 ``PHOTFLAM`` keyword in image headers. This keyword is then used to compute
 ``stmag`` zeropoint for the respective bandpass (e.g.,
-`ACS <http://www.stsci.edu/hst/acs/analysis/zeropoints>`_ and
-`WFC3 <http://www.stsci.edu/hst/wfc3/phot_zp_lbn>`_).
+`ACS <http://www.stsci.edu/hst/instrumentation/acs/data-analysis/zeropoints.html>`_ and
+`WFC3 <http://www.stsci.edu/hst/instrumentation/wfc3/data-analysis/photometric-calibration.html#section-14525acb-c4ec-4fe8-9d25-c9606f1ea62e>`_).
 
 In this tutorial, you will learn how to calculate the ``stmag`` zeropoint for
 the F555W filter in HST/ACS WFC1 detector:


### PR DESCRIPTION
**DO NOT MAKE THESE CHANGES LIVE UNTIL THE NEW WEBSITE IS UP AND RUNNING!**

The Zope --> Jahia transition is currently scheduled for Monday, June 17, 2019. I updated links, but most cannot be tested until after the new site goes live.

Some additional links may need to be changed.  All will need to be tested before deployment -- I suggest running sphinx's `make linkcheck`.

FTP link changes have been removed from this PR.

~Here are a few links I haven't updated, but will probably need to be modified:~
 - ~http://www.stsci.edu/hst/observatory/crds/SIfileInfo/pysynphottables/index_phoenix_models_html~
 - ~http://www.stsci.edu/hst/observatory/crds/documents/TIR-CDBS-2012-01.pdf~
 - ~http://www.stsci.edu/hst/HST_overview/documents/synphot/hst_synphotTOC.html~
 - ~https://aeon.stsci.edu/ssb/trac/astrolib/ticket/218~

~Things I updated but are worthy of further consideration:~
 - ~http://www.sdss.org/dr3/instruments/imager/#filters --> dr7~
 - ~http://www.sdss.org/dr3/algorithms/fluxcal.html     --> dr7~

Closing PR #113.