### PR TITLE
Add pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,6 @@
+[build-system]
+requires = [
+    "setuptools>=30.3.0",
+    "wheel",
+    "numpy",
+]


### PR DESCRIPTION
* Let pip install `numpy` before executing `setup()`

Now that `drizzlepac` requires this package, we cannot have it failing to build because `numpy` is missing.

EDIT: xref spacetelescope/drizzlepac#231