### PR TITLE
Fix CI, add test header

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,34 +1,34 @@
-language: python
-
-python:
-    - 3.6
+language: c
 
 os:
     - linux
+
+# We need a full clone to make sure setuptools_scm works properly
+git:
+    depth: false
 
 env:
     global:
         # The following versions are the 'default' for tests, unless
         # overridden underneath. They are defined here in order to save having
         # to repeat them for all configurations.
+        - PYTHON_VERSION=3.7
         - NUMPY_VERSION=stable
         - ASTROPY_VERSION=stable
-        - PIP_DEPENDENCIES='pytest-remotedata beautifulsoup4'
+        - PIP_DEPENDENCIES='pytest-remotedata pytest-astropy-header beautifulsoup4'
         - CONDA_DEPENDENCIES=''
         - MAIN_CMD='pytest pysynphot'
 
 matrix:
     include:
 
-        - python: 3.6
-
-        - python: 2.7
-          env: ASTROPY_VERSION=lts NUMPY_VERSION=1.15 PYTEST_VERSION="<3.7"
+        - os: linux
 
         # Coverage and also test Astropy dev with remote data
-        - python: 3.7
-          env: ASTROPY_VERSION=development
-               PIP_DEPENDENCIES='codecov pytest-remotedata beautifulsoup4'
+        - os: linux
+          env: PYTHON_VERSION=3.8
+               ASTROPY_VERSION=development
+               PIP_DEPENDENCIES='codecov pytest-remotedata pytest-astropy-header beautifulsoup4'
                CONDA_DEPENDENCIES='pytest-cov coverage requests'
                MAIN_CMD='pytest pysynphot --cov-report= --cov=pysynphot --remote-data'
 
@@ -57,6 +57,7 @@ install:
     # other dependencies.
 
 script:
+    - python setup.py install
     - $MAIN_CMD
 
 after_success:

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,7 @@
 include README.rst
 include LICENSE.md
 include CITATION
+include setup.cfg
 
 recursive-include doc *
 

--- a/pysynphot/conftest.py
+++ b/pysynphot/conftest.py
@@ -2,8 +2,7 @@ import os
 
 from astropy.tests.helper import (enable_deprecations_as_exceptions,
                                   treat_deprecations_as_exceptions)
-# from pytest_astropy_header.display import PYTEST_HEADER_MODULES
-from pytest_astropy_header.display import TESTED_VERSIONS
+from pytest_astropy_header.display import PYTEST_HEADER_MODULES, TESTED_VERSIONS
 
 enable_deprecations_as_exceptions()
 
@@ -11,9 +10,11 @@ enable_deprecations_as_exceptions()
 def pytest_configure(config):
     treat_deprecations_as_exceptions()
 
-    # Configure header here. Examples:
-    # PYTEST_HEADER_MODULES.pop('Pandas', None)
-    # PYTEST_HEADER_MODULES['scikit-image'] = 'skimage'
+    # Configure header here.
+    PYTEST_HEADER_MODULES['astropy'] = 'astropy'
+    PYTEST_HEADER_MODULES.pop('h5py', None)
+    PYTEST_HEADER_MODULES.pop('Pandas', None)
+    PYTEST_HEADER_MODULES.pop('astropy-helpers', None)
 
     from pysynphot import __version__ as version
     packagename = os.path.basename(os.path.dirname(__file__))

--- a/pysynphot/conftest.py
+++ b/pysynphot/conftest.py
@@ -1,0 +1,20 @@
+import os
+
+from astropy.tests.helper import (enable_deprecations_as_exceptions,
+                                  treat_deprecations_as_exceptions)
+# from pytest_astropy_header.display import PYTEST_HEADER_MODULES
+from pytest_astropy_header.display import TESTED_VERSIONS
+
+enable_deprecations_as_exceptions()
+
+
+def pytest_configure(config):
+    treat_deprecations_as_exceptions()
+
+    # Configure header here. Examples:
+    # PYTEST_HEADER_MODULES.pop('Pandas', None)
+    # PYTEST_HEADER_MODULES['scikit-image'] = 'skimage'
+
+    from pysynphot import __version__ as version
+    packagename = os.path.basename(os.path.dirname(__file__))
+    TESTED_VERSIONS[packagename] = version

--- a/pysynphot/svn_version.py
+++ b/pysynphot/svn_version.py
@@ -1,8 +1,0 @@
-# For backwards compatibility with py_etc
-try:
-    from .version import *
-    __svn_version__ = __svn_revision__
-    __full_svn_info__ = __svn_full_info__
-except:
-    __svn_version__ = ''
-    __full_svn_info__ = ''

--- a/pysynphot/test/conftest.py
+++ b/pysynphot/test/conftest.py
@@ -1,8 +1,0 @@
-from astropy.tests.helper import (enable_deprecations_as_exceptions,
-                                  treat_deprecations_as_exceptions)
-
-enable_deprecations_as_exceptions()
-
-
-def pytest_configure(config):
-    treat_deprecations_as_exceptions()

--- a/pysynphot/test/test_primary_area.py
+++ b/pysynphot/test/test_primary_area.py
@@ -25,6 +25,10 @@ GT_FILE_100 = ''
 def setup_module(module):
     global GT_FILE_NO, GT_FILE_100
 
+    # Pin to an older component table
+    refs.COMPTABLE = os.path.join(
+        os.environ['PYSYN_CDBS'], 'mtab', 'OLD_FILES', '39h19082m_tmc.fits')
+
     # A stock graph table on CDBS
     path = os.environ['PYSYN_CDBS']
     GT_FILE_NO = os.path.join(path, 'mtab', 'OLD_FILES', 'n9i1408hm_tmg.fits')

--- a/pysynphot/test/test_ticket157.py
+++ b/pysynphot/test/test_ticket157.py
@@ -28,7 +28,7 @@ def setup_module(module):
 
     old_comptable = refs.COMPTABLE
     refs.COMPTABLE = os.path.join(
-        os.environ['PYSYN_CDBS'], 'mtab', '39h19082m_tmc.fits')
+        os.environ['PYSYN_CDBS'], 'mtab', 'OLD_FILES', '39h19082m_tmc.fits')
 
     old_vegafile = locations.VegaFile
     locations.VegaFile = get_pkg_data_filename(

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,8 +1,9 @@
 [tool:pytest]
-minversion = 3.0
+minversion = 4
 norecursedirs = build doc/build commissioning planning pysynphot/src
 addopts = -p no:warnings
 xfail_strict=true
+astropy_header = true
 
 [flake8]
 # Ignoring these for now:

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,3 +14,27 @@ astropy_header = true
 # I101: imported names are in the wrong order
 # W504: line break after binary operator
 ignore = E265,E266,E501,I100,I101,W504
+
+[coverage:run]
+omit =
+  pysynphot/__init__*
+  pysynphot/conftest.py
+  pysynphot/data/*
+  pysynphot/src/*
+  pysynphot/test/*
+  pysynphot/version*
+  pysynphot/spparser.py
+
+[coverage:report]
+exclude_lines =
+  # Have to re-enable the standard pragma
+  pragma: no cover
+  # Don't complain about packages we have installed
+  except ImportError
+  # Don't complain if tests don't hit assertions
+  raise AssertionError
+  raise NotImplementedError
+  # Don't complain about script hooks
+  def main\(.*\):
+  # Ignore branches that don't pertain to this version of Python
+  pragma: py{ignore_python_version}

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, Extension
 
 setup(
     name='pysynphot',
-    use_scm_version=True,
+    use_scm_version={'write_to': 'pysynphot/version.py'},
     author=('Vicki Laidler, Pey Lian Lim, Matt Davis, Robert Jedrzejewski, '
             'Ivo Busko'),
     author_email='help@stsci.edu',


### PR DESCRIPTION
Fix #126 

Retire Python 2 CI (xref #95) -- code is still there but it won't be tested in Python 2 anymore; if it works for you, great, but if not, you need to switch to Python 3