### PR TITLE
MNT: Replace np.float with float

### DIFF
--- a/pysynphot/binning.py
+++ b/pysynphot/binning.py
@@ -83,7 +83,7 @@ def calculate_bin_centers(edges):
         Array of bin centers. Will be 1D and have one less value than ``edges``.
 
     """
-    edges = np.asanyarray(edges, dtype=np.float)
+    edges = np.asanyarray(edges, dtype=float)
 
     if edges.ndim != 1:
         raise ValueError('edges input array must be 1D.')
@@ -91,7 +91,7 @@ def calculate_bin_centers(edges):
     if edges.size < 2:
         raise ValueError('edges input must have at least two values.')
 
-    centers = np.empty(edges.size - 1, dtype=np.float)
+    centers = np.empty(edges.size - 1, dtype=float)
 
     centers[0] = edges[:2].mean()
 

--- a/pysynphot/spectrum.py
+++ b/pysynphot/spectrum.py
@@ -2739,9 +2739,9 @@ class UniformTransmission(SpectralElement):
         wavelength array as argument.
         """
         if wavelength is None:
-            thru = N.array([self.value], dtype=N.float)
+            thru = N.array([self.value], dtype=float)
         else:
-            thru = N.zeros_like(wavelength, dtype=N.float) + self.value
+            thru = N.zeros_like(wavelength, dtype=float) + self.value
 
         return thru
 

--- a/pysynphot/test/test_binning.py
+++ b/pysynphot/test/test_binning.py
@@ -9,7 +9,7 @@ from .. import binning
 
 @pytest.mark.parametrize(
     ('centers', 'ref'),
-    [(np.arange(10, 20, dtype=np.float), np.arange(9.5, 20)),
+    [(np.arange(10, 20, dtype=float), np.arange(9.5, 20)),
      (2.0 ** np.arange(1, 10), [1, 3, 6, 12, 24, 48, 96, 192, 384, 640])])
 def test_calculate_bin_edges(centers, ref):
     """Test bin edges calculated for an evenly and an unevenly spaced


### PR DESCRIPTION
To avoid `DeprecationWarning` in Numpy 1.20.