### PR TITLE
MNT: Update astropy default branch

### DIFF
--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -46,7 +46,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip wheel setuptools
         python -m pip install numpy pytest-remotedata pytest-astropy-header pytest-cov codecov requests
-        python -m pip install git+https://github.com/astropy/astropy.git@master#egg=astropy
+        python -m pip install git+https://github.com/astropy/astropy.git@main#egg=astropy
         python setup.py install
     # NOTE: If TRDS cannot take the hit, disable --remote-data
     - name: Test with coverage, dev astropy, and remote data


### PR DESCRIPTION
This is an automated update made by the `batchpr` tool :robot: to because `astropy` has changed its default branch! You can report issues to @pllim.