### PR TITLE
Extended retirement date

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,6 +1,6 @@
 # Roadmap for PySynphot
 
-Some time in 2022, make a last release and archive this package.
+Some time in mid-2023, make a last release and archive this package.
 Till then, no active development will happen, except maybe
 critical bug fix, if deemed absolutely necessary.
 


### PR DESCRIPTION
The current ETC development schedule projects a continued need for pysynphot through at least March 2023, possibly longer if the HSTMO decides to keep pyetc running alongside the migrated (H2P) pandeia ETC after its release.