### PR TITLE
assert arrays close on Python 3.8 on Linux

### DIFF
--- a/pysynphot/test/test_v05_tickets.py
+++ b/pysynphot/test/test_v05_tickets.py
@@ -140,7 +140,7 @@ class TestAddMag(object):
 
     def test_subtract(self):
         test = self.faint.addmag(self.delta * -1.0)
-        assert_array_equal(test.flux, self.bright.flux)
+        assert_allclose(test.flux, self.bright.flux)
 
     def testtypecatch(self):
         with pytest.raises(TypeError):


### PR DESCRIPTION
when running tests on Python 3.8 on `ubuntu-latest`:
https://github.com/spacetelescope/stenv/actions/runs/3184495761/jobs/5204620059#step:18:36
```python
self = <pysynphot.test.test_v05_tickets.TestAddMag object at 0x7f86112a66a0>

    def test_subtract(self):
        test = self.faint.addmag(self.delta * -1.0)
>       assert_array_equal(test.flux, self.bright.flux)

E       AssertionError: 
E       Arrays are not equal
E       
E       Mismatched elements: 10000 / 10000 (100%)
E       Max absolute difference: 1.42108547e-14
E       Max relative difference: 7.8949248e-16
E        x: array([17.999987, 17.999987, 17.999987, ..., 17.999987, 17.999987,
E              17.999987])
E        y: array([17.999987, 17.999987, 17.999987, ..., 17.999987, 17.999987,
E              17.999987])
```